### PR TITLE
Added radial_creditcard and radial_paypal_express methods to risk insight

### DIFF
--- a/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Paypal/Radialexpress.php
+++ b/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Paypal/Radialexpress.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2015 Radial, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Radial
+ * Magento Extensions End User License Agreement
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.radial.com/files/pdf/Magento_Connect_Extensions_EULA_050714.pdf
+ *
+ * @copyright   Copyright (c) 2015 Radial, Inc. (http://www.radial.com/)
+ * @license     http://www.radial.com/files/pdf/Magento_Connect_Extensions_EULA_050714.pdf  Radial Magento Extensions End User License Agreement
+ *
+ */
+
+class Radial_Eb2cFraud_Model_Payment_Adapter_Paypal_Radialexpress
+        extends Radial_Eb2cFraud_Model_Payment_Adapter_Type
+{
+        protected function _initialize()
+        {
+                $payment = $this->_order->getPayment();
+                $owner = $this->_order->getBillingAddress()->getName();
+                $this->setExtractCardHolderName($owner)
+                        ->setExtractPaymentAccountUniqueId($this->_getExtractPaymentAccountUniqueId($payment))
+                        ->setExtractIsToken(static::IS_NOT_TOKEN)
+                        ->setExtractPaymentAccountBin(null)
+                        ->setExtractExpireDate(null)
+                        ->setExtractCardType("PY")
+                        ->setExtractTransactionResponses($this->_getPaypalTransactions($payment));
+                return $this;
+        }
+
+        /**
+         * @return Mage_Paypal_Model_Info
+         */
+        protected function _getInfoInstance()
+        {
+                return Mage::getModel('paypal/info');
+        }
+
+        /**
+         * @param  Mage_Payment_Model_Info
+         * @return Mage_Payment_Model_Method_Cc
+         */
+        protected function _getPaypalInfo(Mage_Payment_Model_Info $payment)
+        {
+                return $payment->getAdditionalInformation();
+        }
+
+        /**
+         * @param  Mage_Payment_Model_Info
+         * @return string | null
+         */
+        protected function _getExtractPaymentAccountUniqueId(Mage_Payment_Model_Info $payment)
+        {
+                $info = $this->_getPaypalInfo($payment);
+                return isset($info['paypal_express_checkout_payer_id']) ? $info['paypal_express_checkout_payer_id'] : null;
+        }
+
+        /**
+         * @param  Mage_Payment_Model_Info
+         * @return array
+         */
+        protected function _getPaypalTransactions(Mage_Payment_Model_Info $payment)
+        {
+                $info = $this->_getPaypalInfo($payment);
+                $transArray = array();
+
+                if( isset($info['paypal_express_checkout_address_status']))
+                {
+                        $transArray[] = array('type' => 'PayPalAddress', 'response' => strtolower($info['paypal_express_checkout_address_status']));
+                }
+
+                if( isset($info['paypal_express_checkout_payer_status']))
+                {
+                        $transArray[] = array('type' => 'PayPalPayer', 'response' => strtolower($info['paypal_express_checkout_payer_status']));
+                }
+
+                return $transArray;
+        }
+}

--- a/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Paypal/Radialexpress.php
+++ b/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Paypal/Radialexpress.php
@@ -15,8 +15,8 @@
  *
  */
 
-class Radial_Eb2cFraud_Model_Payment_Adapter_Paypal_Radialexpress
-        extends Radial_Eb2cFraud_Model_Payment_Adapter_Type
+class EbayEnterprise_RiskInsight_Model_Payment_Adapter_Paypal_Radialexpress
+        extends EbayEnterprise_RiskInsight_Model_Payment_Adapter_Type
 {
         protected function _initialize()
         {

--- a/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Radialcreditcard.php
+++ b/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Radialcreditcard.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright (c) 2015 Radial, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Radial
+ * Magento Extensions End User License Agreement
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.radial.com/files/pdf/Magento_Connect_Extensions_EULA_050714.pdf
+ *
+ * @copyright   Copyright (c) 2015 Radial, Inc. (http://www.radial.com/)
+ * @license     http://www.radial.com/files/pdf/Magento_Connect_Extensions_EULA_050714.pdf  Radial Magento Extensions End User License Agreement
+ *
+ */
+
+class Radial_Eb2cFraud_Model_Payment_Adapter_Radialcreditcard
+        extends Radial_Eb2cFraud_Model_Payment_Adapter_Type
+{
+        protected function _initialize()
+        {
+                $payment = $this->_order->getPayment();
+                $owner = $payment->getCcOwner();
+                $additionalInformation = $payment->getAdditionalInformation();
+
+                if(!$owner)
+                {
+                        $owner = $this->_order->getBillingAddress()->getName();
+                }
+
+                $this->setExtractCardHolderName($owner)
+                        ->setExtractPaymentAccountUniqueId($this->_helper->getAccountUniqueId($payment))
+                        ->setExtractIsToken(static::IS_TOKEN)
+                        ->setExtractPaymentAccountBin($this->_helper->getAccountBin($payment))
+                        ->setExtractExpireDate($this->_helper->getPaymentExpireDate($payment))
+                        ->setExtractCardType($this->_config->getTenderTypeForCcType($payment->getCcType() ? $payment->getCcType() : $payment->getMethod()));
+
+                $transArray = array();
+
+                if( isset($additionalInformation['response_code']) && (strcmp($additionalInformation['response_code'], 'AP01') === 0 || strcmp($additionalInformation['response_code'], 'APPROVED') === 0))
+                {
+                        $transArray[] = array('type' => 'primary', 'response' => 'Y');
+                } else {
+                        $transArray[] = array('type' => 'primary', 'response' => 'N');
+                }
+
+                if( isset($additionalInformation['avs_response_code']))
+                {
+                        $transArray[] = array('type' => 'avsZip', 'response' => $additionalInformation['avs_response_code']);
+                        $transArray[] = array('type' => 'avsAddr', 'response' => $additionalInformation['avs_response_code']);
+                }
+
+                if( isset($additionalInformation['cvv2_response_code']))
+                {
+                        $transArray[] = array('type' => 'cvv2',    'response' => $additionalInformation['cvv2_response_code']);
+                }
+
+                if( isset($additionalInformation['phone_response_code']))
+                {
+                        $transArray[] = array('type' => 'AmexPhone',    'response' => $additionalInformation['phone_response_code']);
+                }
+
+                if( isset($additionalInformation['name_response_code']))
+                {
+                        $transArray[] = array('type' => 'AmexName',    'response' => $additionalInformation['name_response_code']);
+                }
+
+                if( isset($additionalInformation['email_response_code']))
+                {
+                        $transArray[] = array('type' => 'AmexEmail',    'response' => $additionalInformation['email_response_code']);
+                }
+
+                $this->setExtractTransactionResponses($transArray);
+
+                return $this;
+        }
+}
+

--- a/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Radialcreditcard.php
+++ b/src/app/code/community/EbayEnterprise/RiskInsight/Model/Payment/Adapter/Radialcreditcard.php
@@ -15,8 +15,8 @@
  *
  */
 
-class Radial_Eb2cFraud_Model_Payment_Adapter_Radialcreditcard
-        extends Radial_Eb2cFraud_Model_Payment_Adapter_Type
+class EbayEnterprise_RiskInsight_Model_Payment_Adapter_Radialcreditcard
+        extends EbayEnterprise_RiskInsight_Model_Payment_Adapter_Type
 {
         protected function _initialize()
         {

--- a/src/app/code/community/EbayEnterprise/RiskInsight/etc/config.xml
+++ b/src/app/code/community/EbayEnterprise/RiskInsight/etc/config.xml
@@ -224,6 +224,8 @@
 					<pbridge_payone_debit>ebayenterprise_riskinsight/payment_adapter_pbridge</pbridge_payone_debit>
 					<ogone>ebayenterprise_riskinsight/payment_adapter_default</ogone>
 					<purchaseorder>ebayenterprise_riskinsight/payment_adapter_purchase_order</purchaseorder>
+					<radial_paypal_express>radial_eb2cfraud/payment_adapter_paypal_radialexpress</radial_paypal_express>
+                                        <radial_creditcard>radial_eb2cfraud/payment_adapter_radialcreditcard</radial_creditcard>
 				</payment_adapter_map>
 			</risk_insight>
 		</ebayenterprise_riskinsight>


### PR DESCRIPTION
Added radial_creditcard and radial_paypal_express methods to risk insight. This should be one of the missing links between modules, there may need to be a piece in regards to automated invoicing but we can discuss that later. 

Please review and merge in. 
